### PR TITLE
Extend reporting part to handle more than one action per repo

### DIFF
--- a/src/main/kotlin/it/krzeminski/githubactionstyping/Logic.kt
+++ b/src/main/kotlin/it/krzeminski/githubactionstyping/Logic.kt
@@ -15,11 +15,11 @@ import kotlin.io.path.exists
  */
 fun validateTypings(repoRoot: Path = Path.of(".")): Pair<Boolean, String> {
     require(repoRoot.exists()) { "The given repo root leads to non-existent dir: $repoRoot" }
-    val manifest = repoRoot.readYamlFile("action") ?:
+    val (manifest, manifestPath) = repoRoot.readYamlFile("action") ?:
         return Pair(false, "No action manifest (action.yml or action.yaml) found!")
 
-    val typesManifest = repoRoot.readYamlFile("action-types") ?:
+    val (typesManifest, _) = repoRoot.readYamlFile("action-types") ?:
     return Pair(false, "No types manifest (action-types.yml or action-types.yaml) found!")
 
-    return manifestsToReport(manifest, typesManifest)
+    return manifestsToReport(repoRoot.relativize(manifestPath), manifest, typesManifest)
 }

--- a/src/main/kotlin/it/krzeminski/githubactionstyping/ManifestsToReport.kt
+++ b/src/main/kotlin/it/krzeminski/githubactionstyping/ManifestsToReport.kt
@@ -7,8 +7,9 @@ import it.krzeminski.githubactionstyping.reporting.toPlaintextReport
 import it.krzeminski.githubactionstyping.validation.ItemValidationResult
 import it.krzeminski.githubactionstyping.validation.buildInputOutputMismatchValidationResult
 import it.krzeminski.githubactionstyping.validation.validate
+import java.nio.file.Path
 
-fun manifestsToReport(manifest: String, typesManifest: String): Pair<Boolean, String> {
+fun manifestsToReport(manifestPath: Path, manifest: String, typesManifest: String): Pair<Boolean, String> {
     val parsedTypesManifest = if (typesManifest.isNotBlank()) {
         parseTypesManifest(typesManifest)
     } else {
@@ -24,6 +25,7 @@ fun manifestsToReport(manifest: String, typesManifest: String): Pair<Boolean, St
 
     if (inputsInManifest != inputsInTypesManifest || outputsInManifest != outputsInTypesManifest) {
         val inputOutputMismatchValidationResult = buildInputOutputMismatchValidationResult(
+            manifestPath = manifestPath,
             inputsInManifest = inputsInManifest,
             inputsInTypesManifest = inputsInTypesManifest,
             outputsInManifest = outputsInManifest,
@@ -48,7 +50,7 @@ fun manifestsToReport(manifest: String, typesManifest: String): Pair<Boolean, St
     printlnDebug("==============================================")
     printlnDebug()
 
-    val validationResult = parsedTypesManifest.validate()
+    val validationResult = parsedTypesManifest.validate(manifestPath)
     val isValid = validationResult.overallResult is ItemValidationResult.Valid
     val report = validationResult.toPlaintextReport()
 

--- a/src/main/kotlin/it/krzeminski/githubactionstyping/parsing/TypesManifestReading.kt
+++ b/src/main/kotlin/it/krzeminski/githubactionstyping/parsing/TypesManifestReading.kt
@@ -4,8 +4,8 @@ import java.nio.file.Path
 import kotlin.io.path.exists
 import kotlin.io.path.readText
 
-fun Path.readYamlFile(nameWithoutExtension: String): String? =
+fun Path.readYamlFile(nameWithoutExtension: String): Pair<String, Path>? =
     listOf("yaml", "yml")
         .map { "$nameWithoutExtension.$it" }
         .firstOrNull { this.resolve(it).exists() }
-        ?.let { this.resolve(it).readText() }
+        ?.let { this.resolve(it).let { Pair(it.readText(), it) } }

--- a/src/main/kotlin/it/krzeminski/githubactionstyping/reporting/PlaintextReport.kt
+++ b/src/main/kotlin/it/krzeminski/githubactionstyping/reporting/PlaintextReport.kt
@@ -1,34 +1,37 @@
 package it.krzeminski.githubactionstyping.reporting
 
-import it.krzeminski.githubactionstyping.validation.ActionValidationResult
 import it.krzeminski.githubactionstyping.validation.ItemValidationResult
+import it.krzeminski.githubactionstyping.validation.RepoValidationResult
 
-fun ActionValidationResult.toPlaintextReport(): String = buildString {
-    appendLine("Overall result: ")
-    this@toPlaintextReport.overallResult.appendStatus(this)
-    appendLine()
+fun RepoValidationResult.toPlaintextReport(): String = buildString {
+    this@toPlaintextReport.pathToActionValidationResult.forEach { (path, resultForAction) ->
+        appendLine("For action with manifest at '$path':")
+        appendLine("Result:")
+        resultForAction.overallResult.appendStatus(this)
+        appendLine()
 
-    appendLine("Inputs:")
-    this@toPlaintextReport.inputs.forEach { (key, value) ->
-        appendLine("• $key:")
-        append("  ")
-        value.appendStatus(this)
-    }
-    if (this@toPlaintextReport.inputs.isEmpty()) {
-        appendLine("None.")
-    }
-    appendLine()
+        appendLine("Inputs:")
+        resultForAction.inputs.forEach { (key, value) ->
+            appendLine("• $key:")
+            append("  ")
+            value.appendStatus(this)
+        }
+        if (resultForAction.inputs.isEmpty()) {
+            appendLine("None.")
+        }
+        appendLine()
 
-    appendLine("Outputs:")
-    this@toPlaintextReport.outputs.forEach { (key, value) ->
-        appendLine("• $key:")
-        append("  ")
-        value.appendStatus(this)
+        appendLine("Outputs:")
+        resultForAction.outputs.forEach { (key, value) ->
+            appendLine("• $key:")
+            append("  ")
+            value.appendStatus(this)
+        }
+        if (resultForAction.outputs.isEmpty()) {
+            appendLine("None.")
+        }
+        appendLine()
     }
-    if (this@toPlaintextReport.outputs.isEmpty()) {
-        appendLine("None.")
-    }
-    appendLine()
 }
 
 private fun ItemValidationResult.appendStatus(

--- a/src/main/kotlin/it/krzeminski/githubactionstyping/validation/Model.kt
+++ b/src/main/kotlin/it/krzeminski/githubactionstyping/validation/Model.kt
@@ -1,0 +1,19 @@
+package it.krzeminski.githubactionstyping.validation
+
+import java.nio.file.Path
+
+data class RepoValidationResult(
+    val overallResult: ItemValidationResult,
+    val pathToActionValidationResult: Map<Path, ActionValidationResult>,
+)
+
+data class ActionValidationResult(
+    val overallResult: ItemValidationResult,
+    val inputs: Map<String, ItemValidationResult> = emptyMap(),
+    val outputs: Map<String, ItemValidationResult> = emptyMap(),
+)
+
+sealed interface ItemValidationResult {
+    data object Valid : ItemValidationResult
+    data class Invalid(val message: String) : ItemValidationResult
+}

--- a/src/test/kotlin/it/krzeminski/githubactionstyping/LogicTest.kt
+++ b/src/test/kotlin/it/krzeminski/githubactionstyping/LogicTest.kt
@@ -21,7 +21,8 @@ class LogicTest : FunSpec({
         assertSoftly {
             isValid shouldBe true
             report shouldBe """
-                Overall result: 
+                For action with manifest at 'action.yml':
+                Result:
                 ${'\u001b'}[32m✔ VALID${'\u001b'}[0m
 
                 Inputs:
@@ -48,7 +49,8 @@ class LogicTest : FunSpec({
         assertSoftly {
             isValid shouldBe false
             report shouldBe """
-                Overall result: 
+                For action with manifest at 'action.yml':
+                Result:
                 ${'\u001b'}[31m❌ INVALID: Some typing is invalid.${'\u001b'}[0m
 
                 Inputs:

--- a/src/test/kotlin/it/krzeminski/githubactionstyping/validation/ManifestValidationTest.kt
+++ b/src/test/kotlin/it/krzeminski/githubactionstyping/validation/ManifestValidationTest.kt
@@ -4,6 +4,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import it.krzeminski.githubactionstyping.parsing.ApiItem
 import it.krzeminski.githubactionstyping.parsing.TypesManifest
+import kotlin.io.path.Path
 
 class ManifestValidationTest : FunSpec({
     context("success cases") {
@@ -28,7 +29,7 @@ class ManifestValidationTest : FunSpec({
             )
 
             // when
-            val result = manifest.validate()
+            val result = manifest.validate(Path("action.yml")).pathToActionValidationResult[Path("action.yml")]
 
             // then
             result shouldBe ActionValidationResult(
@@ -58,7 +59,7 @@ class ManifestValidationTest : FunSpec({
             )
 
             // when
-            val result = manifest.validate()
+            val result = manifest.validate(Path("action.yml")).pathToActionValidationResult[Path("action.yml")]
 
             // then
             result shouldBe ActionValidationResult(
@@ -106,7 +107,7 @@ class ManifestValidationTest : FunSpec({
             )
 
             // when
-            val result = manifest.validate()
+             val result = manifest.validate(Path("action.yml")).pathToActionValidationResult[Path("action.yml")]
 
             // then
             result shouldBe ActionValidationResult(
@@ -135,7 +136,7 @@ class ManifestValidationTest : FunSpec({
             )
 
             // when
-            val result = manifest.validate()
+             val result = manifest.validate(Path("action.yml")).pathToActionValidationResult[Path("action.yml")]
 
             // then
             result shouldBe ActionValidationResult(
@@ -162,7 +163,7 @@ class ManifestValidationTest : FunSpec({
             )
 
             // when
-            val result = manifest.validate()
+             val result = manifest.validate(Path("action.yml")).pathToActionValidationResult[Path("action.yml")]
 
             // then
             result shouldBe ActionValidationResult(
@@ -187,7 +188,7 @@ class ManifestValidationTest : FunSpec({
             )
 
             // when
-            val result = manifest.validate()
+             val result = manifest.validate(Path("action.yml")).pathToActionValidationResult[Path("action.yml")]
 
             // then
             result shouldBe ActionValidationResult(
@@ -213,7 +214,7 @@ class ManifestValidationTest : FunSpec({
             )
 
             // when
-            val result = manifest.validate()
+             val result = manifest.validate(Path("action.yml")).pathToActionValidationResult[Path("action.yml")]
 
             // then
             result shouldBe ActionValidationResult(
@@ -244,7 +245,7 @@ class ManifestValidationTest : FunSpec({
             )
 
             // when
-            val result = manifest.validate()
+             val result = manifest.validate(Path("action.yml")).pathToActionValidationResult[Path("action.yml")]
 
             // then
             result shouldBe ActionValidationResult(
@@ -268,7 +269,7 @@ class ManifestValidationTest : FunSpec({
             )
 
             // when
-            val result = manifest.validate()
+             val result = manifest.validate(Path("action.yml")).pathToActionValidationResult[Path("action.yml")]
 
             // then
             result shouldBe ActionValidationResult(
@@ -288,7 +289,7 @@ class ManifestValidationTest : FunSpec({
             )
 
             // when
-            val result = manifest.validate()
+             val result = manifest.validate(Path("action.yml")).pathToActionValidationResult[Path("action.yml")]
 
             // then
             result shouldBe ActionValidationResult(
@@ -308,7 +309,7 @@ class ManifestValidationTest : FunSpec({
             )
 
             // when
-            val result = manifest.validate()
+             val result = manifest.validate(Path("action.yml")).pathToActionValidationResult[Path("action.yml")]
 
             // then
             result shouldBe ActionValidationResult(
@@ -328,7 +329,7 @@ class ManifestValidationTest : FunSpec({
             )
 
             // when
-            val result = manifest.validate()
+             val result = manifest.validate(Path("action.yml")).pathToActionValidationResult[Path("action.yml")]
 
             // then
             result shouldBe ActionValidationResult(
@@ -348,7 +349,7 @@ class ManifestValidationTest : FunSpec({
             )
 
             // when
-            val result = manifest.validate()
+             val result = manifest.validate(Path("action.yml")).pathToActionValidationResult[Path("action.yml")]
 
             // then
             result shouldBe ActionValidationResult(
@@ -373,7 +374,7 @@ class ManifestValidationTest : FunSpec({
             )
 
             // when
-            val result = manifest.validate()
+             val result = manifest.validate(Path("action.yml")).pathToActionValidationResult[Path("action.yml")]
 
             // then
             result shouldBe ActionValidationResult(
@@ -401,7 +402,7 @@ class ManifestValidationTest : FunSpec({
             )
 
             // when
-            val result = manifest.validate()
+             val result = manifest.validate(Path("action.yml")).pathToActionValidationResult[Path("action.yml")]
 
             // then
             result shouldBe ActionValidationResult(
@@ -437,7 +438,7 @@ class ManifestValidationTest : FunSpec({
             )
 
             // when
-            val result = manifest.validate()
+             val result = manifest.validate(Path("action.yml")).pathToActionValidationResult[Path("action.yml")]
 
             // then
             result shouldBe ActionValidationResult(
@@ -469,7 +470,7 @@ class ManifestValidationTest : FunSpec({
             )
 
             // when
-            val result = manifest.validate()
+             val result = manifest.validate(Path("action.yml")).pathToActionValidationResult[Path("action.yml")]
 
             // then
             result shouldBe ActionValidationResult(
@@ -497,7 +498,7 @@ class ManifestValidationTest : FunSpec({
             )
 
             // when
-            val result = manifest.validate()
+             val result = manifest.validate(Path("action.yml")).pathToActionValidationResult[Path("action.yml")]
 
             // then
             result shouldBe ActionValidationResult(

--- a/src/test/kotlin/it/krzeminski/githubactionstyping/validation/ManifestsToReportTest.kt
+++ b/src/test/kotlin/it/krzeminski/githubactionstyping/validation/ManifestsToReportTest.kt
@@ -4,6 +4,7 @@ import io.kotest.assertions.assertSoftly
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import it.krzeminski.githubactionstyping.manifestsToReport
+import kotlin.io.path.Path
 
 class ManifestsToReportTest : FunSpec({
     test("success case") {
@@ -36,13 +37,14 @@ class ManifestsToReportTest : FunSpec({
         """.trimIndent()
 
         // when
-        val (isValid, report) = manifestsToReport(manifest, typesManifest)
+        val (isValid, report) = manifestsToReport(Path("action.yml"), manifest, typesManifest)
 
         // then
         assertSoftly {
             isValid shouldBe true
             report shouldBe """
-                Overall result: 
+                For action with manifest at 'action.yml':
+                Result:
                 ${'\u001b'}[32m✔ VALID${'\u001b'}[0m
 
                 Inputs:
@@ -95,13 +97,14 @@ class ManifestsToReportTest : FunSpec({
         """.trimIndent()
 
         // when
-        val (isValid, report) = manifestsToReport(manifest, typesManifest)
+        val (isValid, report) = manifestsToReport(Path("action.yml"), manifest, typesManifest)
 
         // then
         assertSoftly {
             isValid shouldBe true
             report shouldBe """
-                Overall result: 
+                For action with manifest at 'action.yml':
+                Result:
                 ${'\u001b'}[32m✔ VALID${'\u001b'}[0m
 
                 Inputs:
@@ -133,13 +136,14 @@ class ManifestsToReportTest : FunSpec({
         val typesManifest = " "
 
         // when
-        val (isValid, report) = manifestsToReport(manifest, typesManifest)
+        val (isValid, report) = manifestsToReport(Path("action.yml"), manifest, typesManifest)
 
         // then
         assertSoftly {
             isValid shouldBe true
             report shouldBe """
-                Overall result: 
+                For action with manifest at 'action.yml':
+                Result:
                 ${'\u001b'}[32m✔ VALID${'\u001b'}[0m
 
                 Inputs:
@@ -180,13 +184,14 @@ class ManifestsToReportTest : FunSpec({
         """.trimIndent()
 
         // when
-        val (isValid, report) = manifestsToReport(manifest, typesManifest)
+        val (isValid, report) = manifestsToReport(Path("action.yml"), manifest, typesManifest)
 
         // then
         assertSoftly {
             isValid shouldBe false
             report shouldBe """
-                Overall result: 
+                For action with manifest at 'action.yml':
+                Result:
                 ${'\u001b'}[31m❌ INVALID: Some typing is invalid.${'\u001b'}[0m
 
                 Inputs:
@@ -239,13 +244,14 @@ class ManifestsToReportTest : FunSpec({
         """.trimIndent()
 
         // when
-        val (isValid, report) = manifestsToReport(manifest, typesManifest)
+        val (isValid, report) = manifestsToReport(Path("action.yml"), manifest, typesManifest)
 
         // then
         assertSoftly {
             isValid shouldBe false
             report shouldBe """
-                Overall result: 
+                For action with manifest at 'action.yml':
+                Result:
                 ${'\u001b'}[31m❌ INVALID: Input/output mismatch detected. Please fix it first, then rerun to see other possible violations.${'\u001b'}[0m
 
                 Inputs:


### PR DESCRIPTION
Part of #204.

After this change, not all actions are validated yet. It's just the part
that handles the validation results is prepared to handle more than one
action.y(a)ml file.
