### PR TITLE
Renovate config: forbid updating to kotest ...-LOCAL

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,11 @@
   "extends": [
     "config:base"
   ],
-  "automerge": true
+  "automerge": true,
+  "packageRules": [
+    {
+      "matchPackageNames": ["io.kotest.multiplatform"],
+      "allowedVersions": "!/LOCAL$/"
+    }
+  ]
 }


### PR DESCRIPTION
The `6.0.0-LOCAL` version shouldn't have been published to the Gradle Plugin Portal, but since it's there, we don't want to update to it because it's missing some artifacts.

Following https://docs.renovatebot.com/configuration-options/#ignore-versions-with-negated-regex-syntax