### PR TITLE
ci: add workflow for making branch runnable

### DIFF
--- a/.github/workflows/make-branch-runnable.yaml
+++ b/.github/workflows/make-branch-runnable.yaml
@@ -2,14 +2,9 @@
 # If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
 # Generated with https://github.com/typesafegithub/github-workflows-kt
 
-name: 'Release'
+name: 'Make branch runnable'
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Used for the tag and the version name. E.g. v1.2.3.'
-        type: 'string'
-        required: true
+  push: {}
 jobs:
   check_yaml_consistency:
     name: 'Check YAML consistency'
@@ -20,11 +15,11 @@ jobs:
       uses: 'actions/checkout@v4'
     - id: 'step-1'
       name: 'Execute script'
-      run: 'rm ''.github/workflows/release.yaml'' && ''.github/workflows/release.main.kts'''
+      run: 'rm ''.github/workflows/make-branch-runnable.yaml'' && ''.github/workflows/release.main.kts'''
     - id: 'step-2'
       name: 'Consistency check'
-      run: 'git diff --exit-code ''.github/workflows/release.yaml'''
-  release:
+      run: 'git diff --exit-code ''.github/workflows/make-branch-runnable.yaml'''
+  make-branch-runnable:
     runs-on: 'ubuntu-latest'
     needs:
     - 'check_yaml_consistency'
@@ -60,34 +55,12 @@ jobs:
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git config user.name "github-actions[bot]"
     - id: 'step-6'
-      name: 'Commit changes to temp branch'
+      name: 'Commit changes'
       working-directory: 'github-actions-typing'
       run: |-
-        git checkout -b temp-branch-for-release
         git add .
         git commit -m "Update dist"
     - id: 'step-7'
       name: 'Push commit'
       working-directory: 'github-actions-typing'
-      run: 'git push --set-upstream origin temp-branch-for-release'
-    - id: 'step-8'
-      name: 'Create and push a patch version tag'
-      working-directory: 'github-actions-typing'
-      run: |-
-        git tag -a "${{ github.event.inputs.version }}" -m "Release version ${{ github.event.inputs.version }}"
-        git push origin "${{ github.event.inputs.version }}"
-    - id: 'step-9'
-      env:
-        GHWKT_GITHUB_CONTEXT_JSON: '${{ toJSON(github) }}'
-      run: 'GHWKT_RUN_STEP=''release:step-9'' ''.github/workflows/release.main.kts'''
-    - id: 'step-10'
-      name: 'Create or update a major version branch'
-      working-directory: 'github-actions-typing'
-      run: |-
-        git branch -D "${{ steps.step-9.outputs.majorVersion }}" || true
-        git checkout -b "${{ steps.step-9.outputs.majorVersion }}"
-        git push origin "${{ steps.step-9.outputs.majorVersion }}" -f
-    - id: 'step-11'
-      name: 'Delete temp branch'
-      working-directory: 'github-actions-typing'
-      run: 'git push origin --delete temp-branch-for-release'
+      run: 'git push'

--- a/.github/workflows/make-branch-runnable.yaml
+++ b/.github/workflows/make-branch-runnable.yaml
@@ -4,7 +4,7 @@
 
 name: 'Make branch runnable'
 on:
-  push: {}
+  workflow_dispatch: {}
 jobs:
   check_yaml_consistency:
     name: 'Check YAML consistency'

--- a/.github/workflows/release.main.kts
+++ b/.github/workflows/release.main.kts
@@ -12,7 +12,9 @@ import io.github.typesafegithub.workflows.actions.actions.Checkout
 import io.github.typesafegithub.workflows.actions.gradle.ActionsSetupGradle
 import io.github.typesafegithub.workflows.annotations.ExperimentalKotlinLogicStep
 import io.github.typesafegithub.workflows.domain.RunnerType
+import io.github.typesafegithub.workflows.domain.triggers.Push
 import io.github.typesafegithub.workflows.domain.triggers.WorkflowDispatch
+import io.github.typesafegithub.workflows.dsl.JobBuilder
 import io.github.typesafegithub.workflows.dsl.expressions.expr
 import io.github.typesafegithub.workflows.dsl.workflow
 import kotlinx.serialization.json.Json
@@ -39,62 +41,8 @@ workflow(
         id = "release",
         runsOn = RunnerType.UbuntuLatest,
     ) {
-        uses(
-            name = "Checkout github-actions-typing",
-            action = Checkout(
-                path = "github-actions-typing"
-            )
-        )
-        uses(
-            name = "Checkout github-actions-typing-catalog",
-            action = Checkout(
-                repository = "typesafegithub/github-actions-typing-catalog",
-                path = "github-actions-typing-catalog"
-            )
-        )
-        uses(action = ActionsSetupGradle())
-        run(
-            workingDirectory = "github-actions-typing",
-            command = "./gradlew build"
-        )
-
-        run(
-            name = "Regenerate the contents of dist directory",
-            workingDirectory = "github-actions-typing",
-            command = """
-                set -euxo pipefail
-
-                rm -rf dist
-                unzip -qq build/distributions/github-actions-typing.zip -d dist
-            """.trimIndent()
-        )
-
-        run(
-            name = "Configure git",
-            workingDirectory = "github-actions-typing",
-            command = """
-                git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-                git config user.name "github-actions[bot]"
-            """.trimIndent()
-        )
-
         val tempBranchName = "temp-branch-for-release"
-
-        run(
-            name = "Commit changes",
-            workingDirectory = "github-actions-typing",
-            command = """
-                git checkout -b $tempBranchName
-                git add .
-                git commit -m "Update dist"
-            """.trimIndent()
-        )
-
-        run(
-            name = "Push commit",
-            workingDirectory = "github-actions-typing",
-            command = "git push --set-upstream origin $tempBranchName",
-        )
+        buildAndCommitDist(branchName = tempBranchName)
 
         val versionExpr = expr { "github.event.inputs.version" }
 
@@ -139,6 +87,96 @@ workflow(
             name = "Delete temp branch",
             workingDirectory = "github-actions-typing",
             command = "git push origin --delete $tempBranchName"
+        )
+    }
+}
+
+workflow(
+    name = "Make branch runnable",
+    on = listOf(
+        Push(),
+    ),
+    sourceFile = __FILE__,
+    targetFileName = "make-branch-runnable.yaml",
+) {
+    job(
+        id = "make-branch-runnable",
+        runsOn = RunnerType.UbuntuLatest,
+    ) {
+        buildAndCommitDist()
+    }
+}
+
+private fun JobBuilder<*>.buildAndCommitDist(branchName: String? = null) {
+    uses(
+        name = "Checkout github-actions-typing",
+        action = Checkout(
+            path = "github-actions-typing"
+        )
+    )
+    uses(
+        name = "Checkout github-actions-typing-catalog",
+        action = Checkout(
+            repository = "typesafegithub/github-actions-typing-catalog",
+            path = "github-actions-typing-catalog"
+        )
+    )
+    uses(action = ActionsSetupGradle())
+    run(
+        workingDirectory = "github-actions-typing",
+        command = "./gradlew build"
+    )
+
+    run(
+        name = "Regenerate the contents of dist directory",
+        workingDirectory = "github-actions-typing",
+        command = """
+                set -euxo pipefail
+
+                rm -rf dist
+                unzip -qq build/distributions/github-actions-typing.zip -d dist
+            """.trimIndent()
+    )
+
+    run(
+        name = "Configure git",
+        workingDirectory = "github-actions-typing",
+        command = """
+                git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+                git config user.name "github-actions[bot]"
+            """.trimIndent()
+    )
+
+    if (branchName != null) {
+        run(
+            name = "Commit changes to temp branch",
+            workingDirectory = "github-actions-typing",
+            command = """
+                git checkout -b $branchName
+                git add .
+                git commit -m "Update dist"
+            """.trimIndent()
+        )
+
+        run(
+            name = "Push commit",
+            workingDirectory = "github-actions-typing",
+            command = "git push --set-upstream origin $branchName",
+        )
+    } else {
+        run(
+            name = "Commit changes",
+            workingDirectory = "github-actions-typing",
+            command = """
+                git add .
+                git commit -m "Update dist"
+            """.trimIndent()
+        )
+
+        run(
+            name = "Push commit",
+            workingDirectory = "github-actions-typing",
+            command = "git push",
         )
     }
 }

--- a/.github/workflows/release.main.kts
+++ b/.github/workflows/release.main.kts
@@ -12,7 +12,6 @@ import io.github.typesafegithub.workflows.actions.actions.Checkout
 import io.github.typesafegithub.workflows.actions.gradle.ActionsSetupGradle
 import io.github.typesafegithub.workflows.annotations.ExperimentalKotlinLogicStep
 import io.github.typesafegithub.workflows.domain.RunnerType
-import io.github.typesafegithub.workflows.domain.triggers.Push
 import io.github.typesafegithub.workflows.domain.triggers.WorkflowDispatch
 import io.github.typesafegithub.workflows.dsl.JobBuilder
 import io.github.typesafegithub.workflows.dsl.expressions.expr
@@ -94,7 +93,7 @@ workflow(
 workflow(
     name = "Make branch runnable",
     on = listOf(
-        Push(),
+        WorkflowDispatch(),
     ),
     sourceFile = __FILE__,
     targetFileName = "make-branch-runnable.yaml",


### PR DESCRIPTION
Before this change, only released versions were runnable. Thanks to the new workflow, it's possible to test any branch by adding distribution files on demand.