### PR TITLE
feat: allow single value in enum type

### DIFF
--- a/src/jvmMain/kotlin/it/krzeminski/githubactionstyping/validation/types/Enum.kt
+++ b/src/jvmMain/kotlin/it/krzeminski/githubactionstyping/validation/types/Enum.kt
@@ -16,8 +16,8 @@ fun ApiItem.validateEnum(): ItemValidationResult {
     if (this.namedValues != null) {
         return ItemValidationResult.Invalid("'named-values' are currently supported only for integers.")
     }
-    if (this.allowedValues.size < 2) {
-        return ItemValidationResult.Invalid("There must be at least two allowed values.")
+    if (this.allowedValues.isEmpty()) {
+        return ItemValidationResult.Invalid("There must be at least one allowed value.")
     }
     return ItemValidationResult.Valid
 }

--- a/src/jvmTest/kotlin/it/krzeminski/githubactionstyping/validation/ManifestValidationTest.kt
+++ b/src/jvmTest/kotlin/it/krzeminski/githubactionstyping/validation/ManifestValidationTest.kt
@@ -313,9 +313,29 @@ class ManifestValidationTest : FunSpec({
 
             // then
             result shouldBe ActionValidationResult(
+                overallResult = ItemValidationResult.Valid,
+                inputs = mapOf(
+                    "enum-input" to ItemValidationResult.Valid,
+                ),
+            )
+        }
+
+        test("enum type with empty list of allowed value") {
+            // given
+            val manifest = TypesManifest(
+                inputs = mapOf(
+                    "enum-input" to ApiItem(type = "enum", allowedValues = emptyList()),
+                ),
+            )
+
+            // when
+            val result = manifest.validate(Path("action.yml")).pathToActionValidationResult[Path("action.yml")]
+
+            // then
+            result shouldBe ActionValidationResult(
                 overallResult = ItemValidationResult.Invalid("Some typing is invalid."),
                 inputs = mapOf(
-                    "enum-input" to ItemValidationResult.Invalid("There must be at least two allowed values."),
+                    "enum-input" to ItemValidationResult.Invalid("There must be at least one allowed value."),
                 ),
             )
         }


### PR DESCRIPTION
Part of #253.

There may be cases where someone wants to make the users explicitly say some single value of enum, e.g. like we discussed here: https://github.com/typesafegithub/github-actions-typing-catalog/pull/45#discussion_r1930710556
This is what we already allow in the schema.