### PR TITLE
feat: allow empty inputs and outputs

### DIFF
--- a/src/jvmMain/kotlin/it/krzeminski/githubactionstyping/ManifestsToReport.kt
+++ b/src/jvmMain/kotlin/it/krzeminski/githubactionstyping/ManifestsToReport.kt
@@ -32,10 +32,10 @@ fun manifestsToReport(manifestAndPath: Pair<String, Path>?, typesManifest: Strin
     }
     val parsedManifest = parseManifest(manifestAndPath.first)
 
-    val inputsInTypesManifest = parsedTypesManifest.inputs.keys
+    val inputsInTypesManifest = parsedTypesManifest.inputs?.keys ?: emptySet()
     val inputsInManifest = parsedManifest.inputs.keys
 
-    val outputsInTypesManifest = parsedTypesManifest.outputs.keys
+    val outputsInTypesManifest = parsedTypesManifest.outputs?.keys ?: emptySet()
     val outputsInManifest = parsedManifest.outputs.keys
 
     if (inputsInManifest != inputsInTypesManifest || outputsInManifest != outputsInTypesManifest) {

--- a/src/jvmMain/kotlin/it/krzeminski/githubactionstyping/parsing/TypesManifestParsing.kt
+++ b/src/jvmMain/kotlin/it/krzeminski/githubactionstyping/parsing/TypesManifestParsing.kt
@@ -9,8 +9,8 @@ import kotlinx.serialization.decodeFromString
 
 @Serializable
 data class TypesManifest(
-    val inputs: Map<String, ApiItem> = emptyMap(),
-    val outputs: Map<String, ApiItem> = emptyMap(),
+    val inputs: Map<String, ApiItem>? = null,
+    val outputs: Map<String, ApiItem>? = null,
 )
 
 @Serializable

--- a/src/jvmMain/kotlin/it/krzeminski/githubactionstyping/validation/ManifestValidation.kt
+++ b/src/jvmMain/kotlin/it/krzeminski/githubactionstyping/validation/ManifestValidation.kt
@@ -11,8 +11,8 @@ import it.krzeminski.githubactionstyping.validation.types.validateString
 import java.nio.file.Path
 
 fun TypesManifest.validate(manifestPath: Path): RepoValidationResult {
-    val inputValidationResults = this.inputs.mapValues { (_, value) -> value.validate() }
-    val outputValidationResults = this.outputs.mapValues { (_, value) -> value.validate() }
+    val inputValidationResults = this.inputs?.mapValues { (_, value) -> value.validate() } ?: emptyMap()
+    val outputValidationResults = this.outputs?.mapValues { (_, value) -> value.validate() } ?: emptyMap()
     val isSomethingInvalid = (inputValidationResults.values + outputValidationResults.values)
         .any { it != ItemValidationResult.Valid }
 


### PR DESCRIPTION
Part of https://github.com/typesafegithub/github-actions-typing/issues/253.

Empty `inputs:` or `outputs:` are sometimes used, just to show that no inputs/outputs are defined.
We also allow it in the schema.