### PR TITLE
feat: add extra validation for enums

### DIFF
--- a/src/jvmMain/kotlin/it/krzeminski/githubactionstyping/validation/types/Enum.kt
+++ b/src/jvmMain/kotlin/it/krzeminski/githubactionstyping/validation/types/Enum.kt
@@ -4,6 +4,9 @@ import it.krzeminski.githubactionstyping.parsing.ApiItem
 import it.krzeminski.githubactionstyping.validation.ItemValidationResult
 
 fun ApiItem.validateEnum(): ItemValidationResult {
+    if (this.name?.isBlank() == true) {
+        return ItemValidationResult.Invalid("Name must not be empty.")
+    }
     if (this.allowedValues == null) {
         return ItemValidationResult.Invalid("Allowed values must be specified.")
     }
@@ -18,6 +21,9 @@ fun ApiItem.validateEnum(): ItemValidationResult {
     }
     if (this.allowedValues.isEmpty()) {
         return ItemValidationResult.Invalid("There must be at least one allowed value.")
+    }
+    if (this.allowedValues.any { it.isBlank() }) {
+        return ItemValidationResult.Invalid("Allowed values must not be empty.")
     }
     return ItemValidationResult.Valid
 }

--- a/src/jvmMain/kotlin/it/krzeminski/githubactionstyping/validation/types/List.kt
+++ b/src/jvmMain/kotlin/it/krzeminski/githubactionstyping/validation/types/List.kt
@@ -11,6 +11,9 @@ fun ApiItem.validateList(): ItemValidationResult {
     if (this.listItem == null) {
         return ItemValidationResult.Invalid("List item information must be specified.")
     }
+    if (this.listItem.name?.isBlank() == true) {
+        return ItemValidationResult.Invalid("List item type: Name must not be empty.")
+    }
     if (this.separator == null) {
         return ItemValidationResult.Invalid("Separator must be specified.")
     }


### PR DESCRIPTION
Part of https://github.com/typesafegithub/github-actions-typing/issues/253.

Fixes several failing test cases identified in https://github.com/typesafegithub/github-actions-typing/pull/261, getting us closer to being consistent with the schema.