### PR TITLE
test: fix duplicate schema test cases

### DIFF
--- a/src/test/resources/bad-typings/inputs_integer_with_empty_name.yml
+++ b/src/test/resources/bad-typings/inputs_integer_with_empty_name.yml
@@ -1,11 +1,8 @@
 # yaml-language-server: $schema=../../../../github-actions-typing.schema.json
 # See https://github.com/typesafegithub/github-actions-typing
 inputs:
-  list-of-integer:
-    type: list
-    separator: ','
-    list-item:
-      type: integer
-      name: ''
-      named-values:
-        foo: 0
+  retries:
+    type: integer
+    name: ''
+    named-values:
+      foo: 0

--- a/src/test/resources/bad-typings/inputs_integer_with_empty_named_value.yml
+++ b/src/test/resources/bad-typings/inputs_integer_with_empty_named_value.yml
@@ -1,11 +1,8 @@
 # yaml-language-server: $schema=../../../../github-actions-typing.schema.json
 # See https://github.com/typesafegithub/github-actions-typing
 inputs:
-  list-of-integer:
-    type: list
-    separator: ','
-    list-item:
-      type: integer
-      name: AllowedValues
-      named-values:
-        '': 0
+  retries:
+    type: integer
+    name: AllowedValues
+    named-values:
+      '': 0

--- a/src/test/resources/bad-typings/inputs_integer_with_empty_named_values.yml
+++ b/src/test/resources/bad-typings/inputs_integer_with_empty_named_values.yml
@@ -1,10 +1,7 @@
 # yaml-language-server: $schema=../../../../github-actions-typing.schema.json
 # See https://github.com/typesafegithub/github-actions-typing
 inputs:
-  list-of-integer:
-    type: list
-    separator: ','
-    list-item:
-      type: integer
-      name: AllowedValues
-      named-values: {}
+  retries:
+    type: integer
+    name: AllowedValues
+    named-values: {}

--- a/src/test/resources/bad-typings/inputs_integer_with_non_integer_named_value.yml
+++ b/src/test/resources/bad-typings/inputs_integer_with_non_integer_named_value.yml
@@ -1,11 +1,8 @@
 # yaml-language-server: $schema=../../../../github-actions-typing.schema.json
 # See https://github.com/typesafegithub/github-actions-typing
 inputs:
-  list-of-integer:
-    type: list
-    separator: ','
-    list-item:
-      type: integer
-      name: AllowedValues
-      named-values:
-        foo: '0'
+  retries:
+    type: integer
+    name: AllowedValues
+    named-values:
+      foo: '0'

--- a/src/test/resources/bad-typings/outputs_integer_with_empty_name.yml
+++ b/src/test/resources/bad-typings/outputs_integer_with_empty_name.yml
@@ -1,11 +1,8 @@
 # yaml-language-server: $schema=../../../../github-actions-typing.schema.json
 # See https://github.com/typesafegithub/github-actions-typing
 outputs:
-  list-of-integer:
-    type: list
-    separator: ','
-    list-item:
-      type: integer
-      name: ''
-      named-values:
-        foo: 0
+  retries:
+    type: integer
+    name: ''
+    named-values:
+      foo: 0

--- a/src/test/resources/bad-typings/outputs_integer_with_empty_named_value.yml
+++ b/src/test/resources/bad-typings/outputs_integer_with_empty_named_value.yml
@@ -1,11 +1,8 @@
 # yaml-language-server: $schema=../../../../github-actions-typing.schema.json
 # See https://github.com/typesafegithub/github-actions-typing
 outputs:
-  list-of-integer:
-    type: list
-    separator: ','
-    list-item:
-      type: integer
-      name: AllowedValues
-      named-values:
-        '': 0
+  retries:
+    type: integer
+    name: AllowedValues
+    named-values:
+      '': 0

--- a/src/test/resources/bad-typings/outputs_integer_with_empty_named_values.yml
+++ b/src/test/resources/bad-typings/outputs_integer_with_empty_named_values.yml
@@ -1,9 +1,6 @@
 # yaml-language-server: $schema=../../../../github-actions-typing.schema.json
 # See https://github.com/typesafegithub/github-actions-typing
 outputs:
-  list-of-integer:
-    type: list
-    separator: ','
-    list-item:
-      type: integer
-      named-values: {}
+  retries:
+    type: integer
+    named-values: {}

--- a/src/test/resources/bad-typings/outputs_integer_with_non_integer_named_value.yml
+++ b/src/test/resources/bad-typings/outputs_integer_with_non_integer_named_value.yml
@@ -1,11 +1,8 @@
 # yaml-language-server: $schema=../../../../github-actions-typing.schema.json
 # See https://github.com/typesafegithub/github-actions-typing
 outputs:
-  list-of-integer:
-    type: list
-    separator: ','
-    list-item:
-      type: integer
-      name: AllowedValues
-      named-values:
-        foo: '0'
+  retries:
+    type: integer
+    name: AllowedValues
+    named-values:
+      foo: '0'


### PR DESCRIPTION
Before this change, we had duplicated tests (with the same YAML, just with different file name), see e.g.:
* https://github.com/typesafegithub/github-actions-typing/blob/ca1309fb40c902b61865f1768b8d03cd4d3a12e6/src/test/resources/bad-typings/inputs_integer_list_item_with_non_integer_named_value.yml
* https://github.com/typesafegithub/github-actions-typing/blob/ca1309fb40c902b61865f1768b8d03cd4d3a12e6/src/test/resources/bad-typings/outputs_integer_list_item_with_non_integer_named_value.yml

# Testing

```
find src/test/resources | grep ml | xargs md5 -q | sort | uniq -c | sort -n | grep -v " 1 "
```

returns nothing.