### PR TITLE
test: make non-integer name tests use string that is not a number

### DIFF
--- a/src/test/resources/bad-typings/inputs_integer_list_item_with_non_integer_named_value.yml
+++ b/src/test/resources/bad-typings/inputs_integer_list_item_with_non_integer_named_value.yml
@@ -8,4 +8,4 @@ inputs:
       type: integer
       name: AllowedValues
       named-values:
-        foo: '0'
+        foo: bar

--- a/src/test/resources/bad-typings/inputs_integer_with_non_integer_named_value.yml
+++ b/src/test/resources/bad-typings/inputs_integer_with_non_integer_named_value.yml
@@ -5,4 +5,4 @@ inputs:
     type: integer
     name: AllowedValues
     named-values:
-      foo: '0'
+      foo: bar

--- a/src/test/resources/bad-typings/outputs_integer_list_item_with_non_integer_named_value.yml
+++ b/src/test/resources/bad-typings/outputs_integer_list_item_with_non_integer_named_value.yml
@@ -8,4 +8,4 @@ outputs:
       type: integer
       name: AllowedValues
       named-values:
-        foo: '0'
+        foo: bar

--- a/src/test/resources/bad-typings/outputs_integer_with_non_integer_named_value.yml
+++ b/src/test/resources/bad-typings/outputs_integer_with_non_integer_named_value.yml
@@ -5,4 +5,4 @@ outputs:
     type: integer
     name: AllowedValues
     named-values:
-      foo: '0'
+      foo: bar


### PR DESCRIPTION
See the discussion at https://github.com/typesafegithub/github-actions-typing/pull/261#discussion_r1938359598

Since strings that contain integers are a tricky edge case, let's for now make these test cases use strings that don't represent integers.

CC @Vampire